### PR TITLE
Clean up the POM a bit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,22 +33,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-scheduler</artifactId>
-      <version>${quarkus.platform.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jsonb</artifactId>
-      <version>${quarkus.platform.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-graphql-client</artifactId>
-      <version>${quarkus.platform.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-client-reactive</artifactId>
-      <version>${quarkus.platform.version}</version>
     </dependency>
     <dependency>
         <groupId>io.quarkiverse.freemarker</groupId>
@@ -72,11 +68,6 @@
     <dependency>
       <groupId>io.quarkiverse.githubapi</groupId>
       <artifactId>quarkus-github-api</artifactId>
-      <version>${quarkus-github-api.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkiverse.githubapi</groupId>
-      <artifactId>quarkus-github-api-deployment</artifactId>
       <version>${quarkus-github-api.version}</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Hey there, I noticed you are using Quarkus GitHub App and found a few issues in the BOM so here is a PR:

- let the BOM enforce the versions
- do not use a -deployment dependency: these should NEVER be added as
  runtime dependencies, they are added automatically by the plugin
  during the deployment and should not be present at runtime

The second part is VERY important. Deployment artifacts come with a ton of dependencies you really don't want at runtime.